### PR TITLE
Create new memory stream for each new upload. 

### DIFF
--- a/CV2WebAssembly/Pages/Home.razor
+++ b/CV2WebAssembly/Pages/Home.razor
@@ -97,9 +97,9 @@
     protected NesColor? Slot3NesColor { get; set; } = null;
 
     private int SpriteCount = 18;
-    protected List<ISprite> Sprites { get; set; } = new(); 
+    protected List<ISprite> Sprites { get; set; } = new();
 
-    protected MemoryStream _nesGameBytes = new MemoryStream(275_000);
+    protected MemoryStream? _nesGameBytes = null;
     private IJSObjectReference? _jsObjectReference = null; 
 
     protected async Task OnSpritePreviewClicked(ISprite sprite)
@@ -156,6 +156,7 @@
         // otherwise things look a tad jumpy. 
         await Task.Delay(TimeSpan.FromSeconds(1)); 
 
+        _nesGameBytes = new MemoryStream(275_000);
         await file.OpenReadStream().CopyToAsync(_nesGameBytes);
         _rom = new NesROM(); 
         await _rom.Load(_nesGameBytes);

--- a/CV2WebAssembly/Pages/_SpritePreview.razor.js
+++ b/CV2WebAssembly/Pages/_SpritePreview.razor.js
@@ -1,9 +1,27 @@
 ﻿export function drawSpriteOnCanvas(canvasId, pixelArray) {
     const canvas = document.getElementById(canvasId);
-    if (canvas != null) {
-        const ctx = canvas.getContext('2d');
-        const img = ctx.createImageData(16, 16);
-        img.data.set(pixelArray);
-        ctx.putImageData(img, 0, 0);
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+
+    // 1. Reset any transforms (so scale/rotate from last draw don't accumulate)
+    if (typeof ctx.resetTransform === 'function') {
+        ctx.resetTransform();
     }
+
+    // 2. Clear the entire canvas
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // 3. Draw the new image data
+    // Option A: create blank ImageData then set its pixels
+    // const img = ctx.createImageData(16, 16);
+    // img.data.set(pixelArray);
+    // ctx.putImageData(img, 0, 0);
+
+    // Option B (more concise): build it directly
+    const img = new ImageData(
+        new Uint8ClampedArray(pixelArray),
+        16,
+        16
+    );
+    ctx.putImageData(img, 0, 0);
 }


### PR DESCRIPTION
A little cleaner way to redisplay over canvas. Recreate the memory stream (don't accidentally append).

closes #18 